### PR TITLE
Scala: aggiungo scheletro del progetto e traccia

### DIFF
--- a/scala/.gitignore
+++ b/scala/.gitignore
@@ -1,0 +1,8 @@
+.ensime*
+.idea
+.gradle
+target/
+/build/
+release.properties
+buildNumber.properties
+/incremental-katas-jvm-langs.iml

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,0 +1,16 @@
+name := "tic-tac-toe"
+
+version := "1.0-SNAPSHOT"
+
+scalaVersion := "2.12.4"
+
+val scalazVersion = "7.2.18"
+
+libraryDependencies ++= Seq(
+	"org.scalaz"    %% "scalaz-core" % scalazVersion,
+	"org.scalatest" %% "scalatest"   % "3.0.1"  % "test"
+)
+
+wartremoverWarnings ++= Warts.unsafe
+
+cancelable in Global := true

--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.0

--- a/scala/project/plugin.sbt
+++ b/scala/project/plugin.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")

--- a/scala/src/main/scala/tic_tac_toe.scala
+++ b/scala/src/main/scala/tic_tac_toe.scala
@@ -1,0 +1,61 @@
+package org.lambdaroma
+
+trait Data_Model {
+
+  type Row = Vector[String]
+  type Matrix = Vector[Row]
+  type Winner = Option[String]
+  type Position = (Int, Int)
+
+  val X = "X"
+  val O = "O"
+  val symbols = List(X, O)
+}
+
+object Test_Matrix {
+  
+  val x_winner =
+    Vector(
+      Vector(" ", "O", "X"),
+      Vector(" ", "X", "O"),
+      Vector("X", " ", " ")
+    )
+
+  val o_winner =
+    Vector(
+      Vector("X", " ", "O"),
+      Vector(" ", "X", "O"),
+      Vector("X", " ", "O")
+    )
+
+  val stalemate =
+    Vector(
+      Vector("X", "O", "X"),
+      Vector("O", "X", "O"),
+      Vector("O", "X", "O")
+    )
+
+}
+
+/** Esercizio 1
+  *
+  * Data una matrice 3x3 che rappresenta una partita a filetto conclusa, 
+  * scrivere una funzione [[winner]] che determina se:
+  * * ha vinto "X", 
+  * * ha vinto "O" 
+  * * o c'è stato il pareggio.
+  * 
+  * Ad esempio, data la matrice: 
+  * 
+  * [ [" ", "O", "X"],
+  *   [" ", "X", "O"],
+  *   ["X", " ", " "] ]
+  * 
+  * La funzione deve restituire l'esito corrispondente alla vittoria di "X".
+  * 
+  */
+object Esercizio_1 extends Data_Model {
+
+    def winner(matrix: Matrix): Winner = ???
+
+}


### PR DESCRIPTION
Per ora la traccia fa riferimento al testo originario del workshop, anche perche' la soluzione che ho sviluppato andrebbe riadattata per la PR in sospeso